### PR TITLE
Browser extension

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -1,0 +1,28 @@
+# Browser Extension
+
+### Requirements
+
+- Firefox (Tested on v94.0.1)
+
+### Installation Instructions
+
+First, import the add-on:
+
+1. In Firefox, go to about:debugging
+2. Click "This Firefox"
+3. Click "Load Temporary Add-On"
+4. Navigate to your saved `manifest.json` file and click on it
+
+### Using the Extension
+
+1. Navigate to https://www.coursera.org/learn/cs-410/home/welcome
+2. Highlight a term you'd like to fuzzy search for
+3. Right-click and select "Send to Fuzzy Search"
+
+### Required JS files
+
+- background.js: This script is required for the "Send to fuzzy search" context menu option
+- query-copy.js: This script is required to copy from the clipboard
+- tabs.js: This script is required to paste query data into the results.html page
+
+---

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -1,0 +1,21 @@
+browser.contextMenus.create({
+  id: 'send-to-fuzzy-search',
+  title: 'Send to fuzzy search',
+  contexts: ['selection'],
+});
+
+browser.contextMenus.onClicked.addListener((info, tab) => {
+  if (info.menuItemId === 'send-to-fuzzy-search') {
+    // pass to content script
+
+    browser.tabs.executeScript(tab.id, {
+      file: 'background-script.js',
+    });
+
+    const customUrl = browser.runtime.getURL('/results.html');
+    var creating = browser.tabs.create({
+      url: customUrl,
+    });
+    creating.then(onCreated, onError);
+  }
+});

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,0 +1,31 @@
+{
+
+    "description": "Adds a browser action icon to the toolbar. Click the button to choose a beast. The active tab's body content is then replaced with a picture of the chosen beast. See https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples#beastify",
+    "manifest_version": 2,
+    "name": "Beastify",
+    "version": "1.0",
+    "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/beastify",
+    "icons": {
+      "48": "icons/beasts-48.png"
+    },
+  
+    "permissions": [
+      "activeTab"
+    ],
+  
+    "browser_action": {
+      "default_icon": "icons/beasts-32.png",
+      "theme_icons": [{
+          "light": "icons/beasts-32-light.png",
+          "dark": "icons/beasts-32.png",
+          "size": 32
+      }],
+      "default_title": "Beastify",
+      "default_popup": "popup/choose_beast.html"
+    },
+  
+    "web_accessible_resources": [
+      "beasts/*.jpg"
+    ]
+  
+  }

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,31 +1,26 @@
 {
-
-    "description": "Adds a browser action icon to the toolbar. Click the button to choose a beast. The active tab's body content is then replaced with a picture of the chosen beast. See https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Examples#beastify",
     "manifest_version": 2,
-    "name": "Beastify",
+    "name": "Context menu: Copy link with types",
+    "description": "Add a context menu option to links to copy the link to the clipboard, as plain text and as a link in rich HTML.",
     "version": "1.0",
-    "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/beastify",
-    "icons": {
-      "48": "icons/beasts-48.png"
+    "homepage_url": "https://github.com/mdn/webextensions-examples/tree/master/context-menu-copy-link-with-types",
+
+    "background": {
+        "scripts": [
+            "background.js"
+        ]
     },
-  
+
+    "content_scripts": [{
+        "matches": ["*://*.coursera.org/learn/cs-410/*"],
+        "js": ["query-copy.js"]
+    }],
+
     "permissions": [
-      "activeTab"
-    ],
-  
-    "browser_action": {
-      "default_icon": "icons/beasts-32.png",
-      "theme_icons": [{
-          "light": "icons/beasts-32-light.png",
-          "dark": "icons/beasts-32.png",
-          "size": 32
-      }],
-      "default_title": "Beastify",
-      "default_popup": "popup/choose_beast.html"
-    },
-  
-    "web_accessible_resources": [
-      "beasts/*.jpg"
+        "activeTab",
+        "tabs",
+        "contextMenus",
+        "clipboardWrite",
+        "clipboardRead"
     ]
-  
-  }
+}

--- a/browser-extension/query-copy.js
+++ b/browser-extension/query-copy.js
@@ -1,0 +1,18 @@
+/*
+copy the selected text to clipboard
+*/
+function copySelection() {
+  var selectedText = window.getSelection().toString().trim();
+
+  if (selectedText) {
+    navigator.clipboard.writeText(selectedText);
+    console.log(selectedText);
+  } // end if selectedText
+} // end copySelection
+
+let url = window.location.href;
+
+/*
+Add copySelection() as a listener to mouseup events.
+*/
+document.addEventListener('mouseup', copySelection);

--- a/browser-extension/results.html
+++ b/browser-extension/results.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
+
+    <title>Fuzzy Search Results</title>
+  </head>
+  <body>
+
+    <div class="container">
+        <div class="row">
+            <h1>Query Results</h1>
+        </div>
+      </div>
+
+      <div class="container">
+        <div class="row">
+            <div class="mb-3">
+                <label for="exampleFormControlTextarea1" class="form-label">Your Results</label>
+                <textarea class="form-control" id="results-area" rows="3" readonly> </textarea>
+              </div>
+        </div>
+        <div class="row">
+
+            <div class="col-4"> 
+                <div class="mb-3">
+                    <label for="exampleFormControlTextarea2" class="form-label">Your Query</label>
+                    <textarea class="form-control" id="query-area" rows="3" > </textarea>
+                  </div>
+            </div>
+            
+              
+        </div>
+        
+      </div>
+      
+    
+
+    <!-- Optional JavaScript; choose one of the two! -->
+    <!-- Option 1: Bootstrap Bundle with Popper -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script>
+    <script src="tabs.js"></script>
+
+  </body>
+</html>

--- a/browser-extension/tabs.js
+++ b/browser-extension/tabs.js
@@ -1,0 +1,9 @@
+function pasteQuery() {
+  navigator.clipboard
+    .readText()
+    .then(
+      (clipText) => (document.getElementById('query-area').innerText = clipText)
+    );
+}
+
+document.addEventListener('DOMContentLoaded', pasteQuery);


### PR DESCRIPTION
Added browser extension prototype

1. See README in subdirectory for installation and usage
2. To retrieve the query from the user, it is assumed that the user will highlight a word anywhere on the Coursera CS 410 page and right-click on it. There is now a "send to fuzzy search" option
3. A new page will pop up that can be used to display results

- To access the query term(s), take a look at the clipboard read request in the `tabs.js` file.
- The new page can also be used to just search for new terms. I haven't built this yet.